### PR TITLE
fix(scaffolding): invalid extends file name in tsconfig.json

### DIFF
--- a/_templates/package/new/tsconfig.json.ejs.t
+++ b/_templates/package/new/tsconfig.json.ejs.t
@@ -2,7 +2,7 @@
 to: packages/<%= name %>/tsconfig.json
 ---
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"


### PR DESCRIPTION
## Overview

In root, tsconfig.json file is not exists. Just fix it right.